### PR TITLE
MOSIP-18794,MOSIP-18959,MOSIP-18323 Fixes

### DIFF
--- a/pre-registration-booking-service/pom.xml
+++ b/pre-registration-booking-service/pom.xml
@@ -145,6 +145,26 @@
 				<version>3.1.0</version>
 				<scope>provided</scope>
 			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-databind</artifactId>
+				<version>2.12.0</version>
+			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-annotations</artifactId>
+				<version>2.12.0</version>
+			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-core</artifactId>
+				<version>2.12.0</version>
+			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.datatype</groupId>
+				<artifactId>jackson-datatype-jsr310</artifactId>
+				<version>2.12.0</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 

--- a/pre-registration-booking-service/src/main/java/io/mosip/preregistration/booking/service/BookingService.java
+++ b/pre-registration-booking-service/src/main/java/io/mosip/preregistration/booking/service/BookingService.java
@@ -805,7 +805,8 @@ public class BookingService implements BookingServiceIntf {
 		response.setId(idUrlCheckSlotAvailability);
 		response.setVersion(versionUrl);
 		try {
-			List<RegistrationCenterDto> regCenter = serviceUtil.getRegCenterMasterData();
+			List<RegistrationCenterDto> regCenter = serviceUtil.getRegCenterMasterData(
+					bookingRequestDTO.getRegistrationCenterId());
 			Boolean isValidRegCenter = regCenter.stream()
 					.anyMatch(iterate -> iterate.getId().contains(bookingRequestDTO.getRegistrationCenterId()));
 

--- a/pre-registration-booking-service/src/test/java/io/mosip/preregistration/booking/test/service/BookingServiceTest.java
+++ b/pre-registration-booking-service/src/test/java/io/mosip/preregistration/booking/test/service/BookingServiceTest.java
@@ -425,7 +425,7 @@ public class BookingServiceTest {
 		Mockito.when(serviceUtil.mandatoryParameterCheck(Mockito.anyString(), Mockito.any())).thenReturn(true);
 		Mockito.when(serviceUtil.isValidRegCenter(Mockito.any())).thenReturn(true);
 		Mockito.when(serviceUtil.isKiosksAvailable(Mockito.any())).thenReturn(true);
-		Mockito.when(serviceUtil.getRegCenterMasterData()).thenReturn(centerList);
+		Mockito.when(serviceUtil.getRegCenterMasterData("10001")).thenReturn(centerList);
 		Mockito.when(bookingDAO.findAvailability(Mockito.anyString(), Mockito.any(), Mockito.any()))
 				.thenReturn(entityList);
 		MainResponseDTO<AvailabilityDto> responseDto = service.getAvailability("10001");
@@ -487,7 +487,7 @@ public class BookingServiceTest {
 		Mockito.when(serviceUtil.validateAppointmentDate(Mockito.any())).thenReturn(true);
 		Mockito.when(serviceUtil.isKiosksAvailable(Mockito.any())).thenReturn(true);
 		Mockito.when(serviceUtil.getApplicationBookingStatus(Mockito.anyString())).thenReturn("Booked");
-		Mockito.when(serviceUtil.getRegCenterMasterData()).thenReturn(centerList);
+		Mockito.when(serviceUtil.getRegCenterMasterData("1")).thenReturn(centerList);
 		// Update status
 		RegistrationBookingEntity bookingEntity2 = new RegistrationBookingEntity();
 		//bookingEntity2.setBookingPK(new RegistrationBookingPK(DateUtils.parseDateToLocalDateTime(new Date())));
@@ -552,7 +552,7 @@ public class BookingServiceTest {
 		Mockito.when(serviceUtil.isKiosksAvailable(Mockito.any())).thenReturn(true);
 		// Mockito.when(serviceUtil.getDemographicStatus(Mockito.anyString())).thenReturn("Pending_Appointment");
 		Mockito.when(serviceUtil.getApplicationBookingStatus(Mockito.anyString())).thenReturn("Pending_Appointment");
-		Mockito.when(serviceUtil.getRegCenterMasterData()).thenReturn(centerList);
+		Mockito.when(serviceUtil.getRegCenterMasterData("10001")).thenReturn(centerList);
 		// Update status
 		RegistrationBookingEntity bookingEntity2 = new RegistrationBookingEntity();
 		//bookingEntity2.setBookingPK(new RegistrationBookingPK(DateUtils.parseDateToLocalDateTime(new Date())));
@@ -719,7 +719,7 @@ public class BookingServiceTest {
 		Mockito.when(serviceUtil.validateAppointmentDate(Mockito.any())).thenReturn(true);
 		Mockito.when(serviceUtil.isKiosksAvailable(Mockito.any())).thenReturn(true);
 		Mockito.when(serviceUtil.getApplicationBookingStatus(Mockito.anyString())).thenReturn("Booked");
-		Mockito.when(serviceUtil.getRegCenterMasterData()).thenReturn(centerList);
+		Mockito.when(serviceUtil.getRegCenterMasterData("10001")).thenReturn(centerList);
 	}
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
@@ -813,7 +813,7 @@ public class BookingServiceTest {
 		Mockito.when(serviceUtil.validateAppointmentDate(Mockito.any())).thenReturn(true);
 		Mockito.when(serviceUtil.isKiosksAvailable(Mockito.any())).thenReturn(true);
 		Mockito.when(serviceUtil.getApplicationBookingStatus(Mockito.anyString())).thenReturn("Booked");
-		Mockito.when(serviceUtil.getRegCenterMasterData()).thenReturn(centerList);
+		Mockito.when(serviceUtil.getRegCenterMasterData("10001")).thenReturn(centerList);
 
 		MainResponseDTO mainResponseDTO = new MainResponseDTO<>();
 		mainResponseDTO.setErrors(null);
@@ -923,7 +923,7 @@ public class BookingServiceTest {
 		Mockito.when(bookingDAO.findByPreRegistrationId("23587986034785")).thenReturn(bookingEntity2);
 		Mockito.when(serviceUtil.isKiosksAvailable(Mockito.any())).thenReturn(true);
 		Mockito.when(bookingDAO.updateAvailibityEntity(availableEntity)).thenReturn(availableEntity);
-		Mockito.when(serviceUtil.getRegCenterMasterData()).thenReturn(centerList);
+		Mockito.when(serviceUtil.getRegCenterMasterData("10001")).thenReturn(centerList);
 //		MainResponseDTO<BookingStatus> response = service.bookMultiAppointment(bookingRequestDTOs);
 //		assertNotNull(response.getResponse().getBookingStatusResponse().get(0).getBookingMessage());
 	}
@@ -1213,7 +1213,7 @@ public class BookingServiceTest {
 		Mockito.when(serviceUtil.mandatoryParameterCheckforCancel(Mockito.anyString())).thenReturn(true);
 		Mockito.when(serviceUtil.getDemographicStatusForCancel(Mockito.anyString())).thenReturn(true);
 		Mockito.when(serviceUtil.getApplicationBookingStatus("23587986034785")).thenReturn("Expired");
-		Mockito.when(serviceUtil.getRegCenterMasterData()).thenReturn(centerList);
+		Mockito.when(serviceUtil.getRegCenterMasterData("10001")).thenReturn(centerList);
 		Mockito.when(bookingDAO.findByRegDateAndRegcntrIdAndFromTimeAndToTime(Mockito.any(), Mockito.any(),
 				Mockito.any(), Mockito.any())).thenReturn(availableEntity);
 		Mockito.when(bookingDAO.updateAvailibityEntity(availableEntity)).thenReturn(availableEntity);
@@ -1277,7 +1277,7 @@ public class BookingServiceTest {
 		Mockito.when(serviceUtil.validateAppointmentDate(Mockito.any())).thenReturn(true);
 		Mockito.when(serviceUtil.isKiosksAvailable(Mockito.any())).thenReturn(true);
 		Mockito.when(serviceUtil.getApplicationBookingStatus("23587986034785")).thenReturn("Booked");
-		Mockito.when(serviceUtil.getRegCenterMasterData()).thenReturn(centerList);
+		Mockito.when(serviceUtil.getRegCenterMasterData("10001")).thenReturn(centerList);
 		Mockito.when(serviceUtil.timeSpanCheckForCancle(Mockito.any())).thenThrow(ex);
 
 		Mockito.when(bookingDAO.findByPreRegistrationId("23587986034785")).thenReturn(bookingEntity);
@@ -1447,7 +1447,7 @@ public class BookingServiceTest {
 		Mockito.when(serviceUtil.validateAppointmentDate(Mockito.any())).thenReturn(true);
 		Mockito.when(serviceUtil.isKiosksAvailable(Mockito.any())).thenReturn(true);
 		Mockito.when(serviceUtil.getApplicationBookingStatus("23587986034785")).thenReturn("Booked");
-		Mockito.when(serviceUtil.getRegCenterMasterData()).thenReturn(centerList);
+		Mockito.when(serviceUtil.getRegCenterMasterData("10001")).thenReturn(centerList);
 		Mockito.when(bookingDAO.findRegCenter(Mockito.any())).thenReturn(regCenterList);
 		Mockito.when(bookingDAO.findByRegDateAndRegcntrIdAndFromTimeAndToTime(Mockito.any(), Mockito.anyString(),
 				Mockito.any(), Mockito.any())).thenReturn(availableEntityNull);
@@ -1581,7 +1581,7 @@ public class BookingServiceTest {
 		Mockito.when(serviceUtil.validateAppointmentDate(Mockito.any())).thenReturn(true);
 		Mockito.when(serviceUtil.isKiosksAvailable(Mockito.any())).thenReturn(true);
 		Mockito.when(serviceUtil.getApplicationBookingStatus("23587986034785")).thenReturn("Expired");
-		Mockito.when(serviceUtil.getRegCenterMasterData()).thenReturn(centerList);
+		Mockito.when(serviceUtil.getRegCenterMasterData("10001")).thenReturn(centerList);
 		// Update status
 		RegistrationBookingEntity bookingEntity2 = new RegistrationBookingEntity();
 		//bookingEntity2.setBookingPK(new RegistrationBookingPK(DateUtils.parseDateToLocalDateTime(new Date())));
@@ -1694,7 +1694,7 @@ public class BookingServiceTest {
 		Mockito.when(serviceUtil.validateAppointmentDate(Mockito.any())).thenReturn(true);
 		Mockito.when(serviceUtil.isKiosksAvailable(Mockito.any())).thenReturn(true);
 		Mockito.when(serviceUtil.getApplicationBookingStatus("23587986034785")).thenReturn("Expired");
-		Mockito.when(serviceUtil.getRegCenterMasterData()).thenReturn(centerList);
+		Mockito.when(serviceUtil.getRegCenterMasterData("10001")).thenReturn(centerList);
 
 		MainResponseDTO mainResponseDTO = new MainResponseDTO<>();
 		mainResponseDTO.setErrors(null);

--- a/pre-registration-booking-service/src/test/java/io/mosip/preregistration/booking/test/service/util/BookingServiceUtilTest.java
+++ b/pre-registration-booking-service/src/test/java/io/mosip/preregistration/booking/test/service/util/BookingServiceUtilTest.java
@@ -399,7 +399,7 @@ public class BookingServiceUtilTest {
 				Mockito.eq(new ParameterizedTypeReference<ResponseWrapper<RegistrationCenterResponseDto>>() {
 				}))).thenReturn(res);
 
-		serviceUtil.getRegCenterMasterData();
+		serviceUtil.getRegCenterMasterData("10001");
 
 	}
 
@@ -411,7 +411,7 @@ public class BookingServiceUtilTest {
 				Mockito.eq(new ParameterizedTypeReference<ResponseWrapper<RegistrationCenterResponseDto>>() {
 				}))).thenThrow(ex);
 
-		serviceUtil.getRegCenterMasterData();
+		serviceUtil.getRegCenterMasterData("10001");
 
 	}
 


### PR DESCRIPTION
MOSIP-18794 Object Mapper library is used without the Afterburner module in prereg module 
MOSIP-18959 Unable to book an appointment in qa-triple-rc2, "No slots available" message is displayed after selecting the center
MOSIP-18323 Pre-reg: Working days and working hours for a reg center created in non mandatory language is not reflecting appropriately.
